### PR TITLE
Make toolbar controls solid and clarify profile storage

### DIFF
--- a/src/index.html.jinja2
+++ b/src/index.html.jinja2
@@ -184,14 +184,14 @@
     <model-viewer id="model" camera-controls interaction-prompt="none" orientation="0deg -90deg 0deg"
                   environment-image="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAARCAAIABADASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAn/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AJVAA//Z"></model-viewer>
     <div id="controls">
-        <button id="render" type="button" class="btn btn-primary">Render<span id="render-state" class="d-none">ing… <span
+        <button id="render" type="button" class="btn btn-secondary">Render<span id="render-state" class="d-none">ing… <span
                 class="spinner-border spinner-border-sm" aria-hidden="true"></span></span></button>
         <label class="btn btn-secondary" for="auto-render">
             <input class="form-check-input" type="checkbox" id="auto-render" checked>
             Auto Render
         </label>
         <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#profiles-modal">Profiles</button>
-        <button id="download-stl" type="button" class="btn btn-secondary">Save STL</button>
+        <button id="download-stl" type="button" class="btn btn-primary">Save STL</button>
         <div id="render-error" class="alert alert-danger mt-2 d-none" role="alert">
             <div class="d-flex align-items-center justify-content-between gap-2 flex-wrap">
                 <div>


### PR DESCRIPTION
## Summary
- switch Auto Render and Profiles controls back to solid secondary button styling in the main toolbar
- update the profiles dialog description to explicitly say profiles are saved in the browser