### PR TITLE
Show outdated model as translucent during rendering

### DIFF
--- a/src/index.html.jinja2
+++ b/src/index.html.jinja2
@@ -43,6 +43,24 @@
             height: 100%;
             width: 100%;
         }
+
+        #pane-left {
+            position: relative;
+        }
+
+        #model.is-outdated {
+            opacity: 0.55;
+        }
+
+        #model-loading-overlay {
+            position: absolute;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            pointer-events: none;
+            z-index: 10;
+        }
         @media only screen and (max-width: 992px) {
             body {
                 display: block;
@@ -183,6 +201,9 @@
     <!-- the environment image disables the default lighting -->
     <model-viewer id="model" camera-controls interaction-prompt="none" orientation="0deg -90deg 0deg"
                   environment-image="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAARCAAIABADASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAn/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AJVAA//Z"></model-viewer>
+    <div id="model-loading-overlay" class="d-none" aria-hidden="true">
+        <span class="spinner-border" aria-hidden="true"></span>
+    </div>
     <div id="controls">
         <button id="render" type="button" class="btn btn-secondary">Render<span id="render-state" class="d-none">ing… <span
                 class="spinner-border spinner-border-sm" aria-hidden="true"></span></span></button>

--- a/src/static/editor/dom.js
+++ b/src/static/editor/dom.js
@@ -17,5 +17,6 @@ export function getDomRefs() {
         renderErrorLog: document.getElementById("render-error-log"),
         renderErrorCopy: document.getElementById("render-error-copy"),
         modelViewer: document.getElementById("model"),
+        modelLoadingOverlay: document.getElementById("model-loading-overlay"),
     };
 }

--- a/src/static/editor/rendering.js
+++ b/src/static/editor/rendering.js
@@ -95,8 +95,18 @@ export function createRenderer({
         if (rendering) {
             lastResult = null;
             dom.renderState.classList.remove("d-none");
+            dom.modelViewer.classList.add("is-outdated");
+            dom.modelViewer.setAttribute("aria-busy", "true");
+            if (dom.modelLoadingOverlay) {
+                dom.modelLoadingOverlay.classList.remove("d-none");
+            }
         } else {
             dom.renderState.classList.add("d-none");
+            dom.modelViewer.classList.remove("is-outdated");
+            dom.modelViewer.setAttribute("aria-busy", "false");
+            if (dom.modelLoadingOverlay) {
+                dom.modelLoadingOverlay.classList.add("d-none");
+            }
             if (isDirty) {
                 isDirty = false;
                 startRender();


### PR DESCRIPTION
## Summary
- Keep the previously rendered model visible while a new render is running, but dim it with reduced opacity.
- Add a centered loading spinner overlay above the model viewer during render execution.
- Toggle the overlay and model dimming from the existing render lifecycle state in `rendering.js`, with `aria-busy` updates for accessibility.

## Verification
- `uv run pytest -q`
- `uv run python src/generate.py --config editor.toml --output out_verify_overlay`