### PR TITLE
Add export-file-stem model setting with deprecated prefix fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Project metadata is defined in the `[project]` table. All settings are optional.
 [project]
 name = "MyProject"
 uri = "https://github.com/user/project"
-# Optional: This is used as the name of generated STL files
+# Optional: This is used as the name of generated STL files (deprecated; use model export-file-stem)
 export-filename-prefix = "my-project"
 # Optional: This is injected at the end of the <head> tag of all generated pages
 head-extra = "<script>alert('Hello world!')</script>"
@@ -121,6 +121,12 @@ Also in the `[[model]]` table, you can define various configuration options for 
 file = "my-model.scad"
 # Extra HTML to show in the description section of the model page
 description-extra-html = "<p>This is a description of my model.</p>"
+
+# Optional: Configure the exported STL filename stem (without extension)
+# Use a fixed name:
+export-file-stem = {fixed = "my-model"}
+# Or derive it from model parameters (same JS scope as display-condition):
+export-file-stem = {js = "magnets ? 'bin-with-magnets' : 'bin'"}
 ```
 
 #### Additional Parameters

--- a/config-schema.json
+++ b/config-schema.json
@@ -134,6 +134,22 @@
           "type": "string",
           "description": "Per-file HTML description"
         },
+        "export-file-stem": {
+          "type": ["object", "null"],
+          "description": "Filename stem (without extension) for exported files",
+          "default": null,
+          "properties": {
+            "js": {
+              "type": "string",
+              "description": "JavaScript expression"
+            },
+            "fixed": {
+              "type": ["string", "null"],
+              "description": "Fixed value",
+              "default": null
+            }
+          }
+        },
         "param-metadata": {
           "type": "object",
           "description": "Additional metadata for model parameters",

--- a/editor.toml
+++ b/editor.toml
@@ -3,6 +3,7 @@ head-extra = '<script defer src="https://um.yawk.at/script.js" data-website-id="
 
 [[model]]
 file = "test.scad"
+export-file-stem = {js = "shape + '-' + width + 'x' + depth + 'x' + height"}
 # Track render events with selected model parameters
 umami-track-render = ["shape", "width", "depth", "height"]
 # Track export events with additional parameters

--- a/src/config_generated.py
+++ b/src/config_generated.py
@@ -55,6 +55,11 @@ class Openscad(BaseModel):
     )
 
 
+class ExportFileStem(BaseModel):
+    js: str | None = Field(None, description='JavaScript expression')
+    fixed: str | None = Field(None, description='Fixed value')
+
+
 class Presets(BaseModel):
     text: str | None = Field(
         'Presets', description='Text to display in the presets dropdown'
@@ -125,6 +130,11 @@ class ModelConfig(BaseModel):
     )
     description_extra_html: str | None = Field(
         None, alias='description-extra-html', description='Per-file HTML description'
+    )
+    export_file_stem: ExportFileStem | None = Field(
+        None,
+        alias='export-file-stem',
+        description='Filename stem (without extension) for exported files',
     )
     param_metadata: dict[str, ParamMetadata] | None = Field(
         {},

--- a/src/index.html.jinja2
+++ b/src/index.html.jinja2
@@ -186,7 +186,7 @@
                 {%- endfor %}
             ],
             scadInputPath: {{ ctx.relative | json_dump }},
-            exportFilenamePrefix: {{ config.project.export_filename_prefix | json_dump }},
+            exportFileStem: {% if ctx.config.export_file_stem is not none %}{{ ctx.config.export_file_stem | json_dump }}{% elif config.project.export_filename_prefix %}{{ {'fixed': config.project.export_filename_prefix} | json_dump }}{% else %}null{% endif %},
             umamiTrackRender: {% if ctx.config.umami_track_render is not none %}{{ ctx.config.umami_track_render | json_dump }}{% else %}null{% endif %},
             umamiTrackExport: {% if ctx.config.umami_track_export is not none %}{{ ctx.config.umami_track_export | json_dump }}{% else %}null{% endif %},
         };

--- a/src/index.html.jinja2
+++ b/src/index.html.jinja2
@@ -186,7 +186,7 @@
                 {%- endfor %}
             ],
             scadInputPath: {{ ctx.relative | json_dump }},
-            exportFileStem: {% if ctx.config.export_file_stem is not none %}{{ ctx.config.export_file_stem | json_dump }}{% elif config.project.export_filename_prefix %}{{ {'fixed': config.project.export_filename_prefix} | json_dump }}{% else %}null{% endif %},
+            exportFileStem: {% if ctx.config.export_file_stem is not none %}{{ ctx.config.export_file_stem.model_dump(by_alias=True) | json_dump }}{% elif config.project.export_filename_prefix %}{{ {'fixed': config.project.export_filename_prefix} | json_dump }}{% else %}null{% endif %},
             umamiTrackRender: {% if ctx.config.umami_track_render is not none %}{{ ctx.config.umami_track_render | json_dump }}{% else %}null{% endif %},
             umamiTrackExport: {% if ctx.config.umami_track_export is not none %}{{ ctx.config.umami_track_export | json_dump }}{% else %}null{% endif %},
         };

--- a/src/static/editor/main.js
+++ b/src/static/editor/main.js
@@ -305,7 +305,7 @@ function initProfilesUi() {
 renderer = createRenderer({
     workerUrl: config.workerUrl,
     scadInputPath: config.scadInputPath,
-    exportFilenamePrefix: config.exportFilenamePrefix,
+    exportFileStem: config.exportFileStem,
     umamiTrackRender: config.umamiTrackRender,
     umamiTrackExport: config.umamiTrackExport,
     dom,

--- a/src/static/editor/rendering.js
+++ b/src/static/editor/rendering.js
@@ -64,7 +64,7 @@ function showRenderError(dom, { summary, log }) {
  * @param {object} opts
  * @param {string}   opts.workerUrl
  * @param {string}   opts.scadInputPath
- * @param {string}   opts.exportFilenamePrefix
+ * @param {*}        opts.exportFileStem     - null or {fixed?: string, js?: string}
  * @param {*}        opts.umamiTrackRender   - null or string[]
  * @param {*}        opts.umamiTrackExport   - null or string[]
  * @param {object}   opts.dom                - from getDomRefs()
@@ -74,7 +74,7 @@ function showRenderError(dom, { summary, log }) {
 export function createRenderer({
     workerUrl,
     scadInputPath,
-    exportFilenamePrefix,
+    exportFileStem,
     umamiTrackRender,
     umamiTrackExport,
     dom,
@@ -223,7 +223,26 @@ export function createRenderer({
         if (lastResult != null) {
             const link = document.createElement("a");
             link.href = URL.createObjectURL(new Blob([lastResult.stl], { type: "application/octet-stream" }));
-            link.download = exportFilenamePrefix + ".stl";
+            const customization = getCustomization();
+            let stem = "";
+            if (exportFileStem !== null) {
+                if (exportFileStem.js != null) {
+                    try {
+                        const expression = String(exportFileStem.js);
+                        const evaluator = new Function(...Object.keys(customization), "return " + expression);
+                        const evaluated = evaluator(...Object.values(customization));
+                        stem = evaluated == null ? "" : String(evaluated);
+                    } catch (e) {
+                        console.warn("Failed to evaluate export-file-stem expression", e);
+                        if (exportFileStem.fixed != null) {
+                            stem = String(exportFileStem.fixed);
+                        }
+                    }
+                } else if (exportFileStem.fixed != null) {
+                    stem = String(exportFileStem.fixed);
+                }
+            }
+            link.download = stem + ".stl";
             document.body.appendChild(link);
             link.click();
             link.remove();


### PR DESCRIPTION
## Summary
- add `model` / `model-template` configuration option `export-file-stem` as an object with `fixed` or `js`
- normalize server-side fallback in the template: if `export-file-stem` is absent, use deprecated `project.export-filename-prefix` as `{fixed: ...}`
- remove JavaScript dependency on `exportFilenamePrefix` and compute STL filename from `exportFileStem` only
- document the new option and deprecate `export-filename-prefix` in README
- add a dynamic `export-file-stem` example to `editor.toml` for `test.scad`

## Testing
- `uv run pytest -q`