### PR TITLE
Add colored OFF preview support

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ description-extra-html = "<p>This is a description of my model.</p>"
 export-file-stem = {fixed = "my-model"}
 # Or derive it from model parameters (same JS scope as display-condition):
 export-file-stem = {js = "magnets ? 'bin-with-magnets' : 'bin'"}
+
+# Preview rendering style. Use "colors" to show OpenSCAD face colors with neutral lighting.
+preview-style = "colors"
 ```
 
 #### Additional Parameters

--- a/config-schema.json
+++ b/config-schema.json
@@ -155,6 +155,12 @@
           "type": "string",
           "description": "Per-file HTML description"
         },
+        "preview-style": {
+          "type": ["string", "null"],
+          "enum": ["shaded", "colors", null],
+          "default": null,
+          "description": "Preview rendering style. The shaded style matches older gray previews; colors uses OpenSCAD face colors with neutral lighting."
+        },
         "export-file-stem": {
           "type": ["object", "null"],
           "description": "Filename stem (without extension) for exported files",

--- a/editor.toml
+++ b/editor.toml
@@ -6,6 +6,7 @@ commit = "fbcdfdd511b6abfde93c43c8f85c2bd24ee7a02d"
 
 [[model]]
 file = "test.scad"
+preview-style = "colors"
 export-file-stem = {js = "shape + '-' + width + 'x' + depth + 'x' + height"}
 # Track render events with selected model parameters
 umami-track-render = ["shape", "width", "depth", "height"]

--- a/src/config_generated.py
+++ b/src/config_generated.py
@@ -77,6 +77,12 @@ class Openscad(BaseModel):
     )
 
 
+class PreviewStyle(Enum):
+    shaded = 'shaded'
+    colors = 'colors'
+    NoneType_None = None
+
+
 class ExportFileStem(BaseModel):
     js: str | None = Field(None, description='JavaScript expression')
     fixed: str | None = Field(None, description='Fixed value')
@@ -152,6 +158,11 @@ class ModelConfig(BaseModel):
     )
     description_extra_html: str | None = Field(
         None, alias='description-extra-html', description='Per-file HTML description'
+    )
+    preview_style: PreviewStyle | None = Field(
+        None,
+        alias='preview-style',
+        description='Preview rendering style. The shaded style matches older gray previews; colors uses OpenSCAD face colors with neutral lighting.',
     )
     export_file_stem: ExportFileStem | None = Field(
         None,

--- a/src/index.html.jinja2
+++ b/src/index.html.jinja2
@@ -186,6 +186,7 @@
                 {%- endfor %}
             ],
             scadInputPath: {{ ctx.relative | json_dump }},
+            previewStyle: {{ ("shaded" if ctx.config.preview_style is none else (ctx.config.preview_style if ctx.config.preview_style is string else (ctx.config.preview_style.value or "shaded"))) | json_dump }},
             exportFileStem: {% if ctx.config.export_file_stem is not none %}{{ ctx.config.export_file_stem.model_dump(by_alias=True) | json_dump }}{% elif config.project.export_filename_prefix %}{{ {'fixed': config.project.export_filename_prefix} | json_dump }}{% else %}null{% endif %},
             umamiTrackRender: {% if ctx.config.umami_track_render is not none %}{{ ctx.config.umami_track_render | json_dump }}{% else %}null{% endif %},
             umamiTrackExport: {% if ctx.config.umami_track_export is not none %}{{ ctx.config.umami_track_export | json_dump }}{% else %}null{% endif %},

--- a/src/static/editor/main.js
+++ b/src/static/editor/main.js
@@ -305,6 +305,7 @@ function initProfilesUi() {
 renderer = createRenderer({
     workerUrl: config.workerUrl,
     scadInputPath: config.scadInputPath,
+    previewStyle: config.previewStyle,
     exportFileStem: config.exportFileStem,
     umamiTrackRender: config.umamiTrackRender,
     umamiTrackExport: config.umamiTrackExport,

--- a/src/static/editor/off.js
+++ b/src/static/editor/off.js
@@ -1,0 +1,198 @@
+const HEADER_RE = /^(?:C)?OFF$/;
+
+function normalizeColorComponent(value) {
+    if (value > 1) {
+        return value / 255;
+    }
+    return value;
+}
+
+function parseColor(tokens, cursor, available) {
+    if (available < 3) {
+        return null;
+    }
+    const r = Number(tokens[cursor]);
+    const g = Number(tokens[cursor + 1]);
+    const b = Number(tokens[cursor + 2]);
+    if (![r, g, b].every(Number.isFinite)) {
+        return null;
+    }
+    return [
+        normalizeColorComponent(r),
+        normalizeColorComponent(g),
+        normalizeColorComponent(b),
+    ];
+}
+
+function tokenizeOffLines(text) {
+    const lines = [];
+    for (const line of text.split(/\r?\n/)) {
+        const uncommented = line.replace(/#.*/, "").trim();
+        if (uncommented) {
+            lines.push(uncommented.split(/\s+/));
+        }
+    }
+    return lines;
+}
+
+/**
+ * Parse OFF/COFF text into non-indexed triangle data.
+ *
+ * OpenSCAD writes face colors at the end of face records for colored models.
+ * COFF vertex colors are also supported so the parser remains useful for
+ * generic colored OFF files.
+ */
+export function parseOffMesh(text) {
+    const lines = tokenizeOffLines(text);
+    if (lines.length === 0) {
+        throw new Error("Empty OFF file");
+    }
+
+    const firstLine = lines.shift();
+    const header = firstLine.shift();
+    if (!HEADER_RE.test(header)) {
+        throw new Error(`Unsupported OFF header: ${header}`);
+    }
+    const hasVertexColors = header.includes("C");
+
+    const countsLine = firstLine.length > 0 ? firstLine : lines.shift();
+    if (!countsLine) {
+        throw new Error("Missing OFF counts");
+    }
+    const vertexCount = Number(countsLine[0]);
+    const faceCount = Number(countsLine[1]);
+    if (!Number.isInteger(vertexCount) || vertexCount < 0) {
+        throw new Error("Invalid OFF vertex count");
+    }
+    if (!Number.isInteger(faceCount) || faceCount < 0) {
+        throw new Error("Invalid OFF face count");
+    }
+
+    const vertices = [];
+    const vertexColors = [];
+    for (let i = 0; i < vertexCount; i++) {
+        const line = lines.shift();
+        if (!line) {
+            throw new Error(`Missing OFF vertex ${i}`);
+        }
+        const x = Number(line[0]);
+        const y = Number(line[1]);
+        const z = Number(line[2]);
+        if (![x, y, z].every(Number.isFinite)) {
+            throw new Error(`Invalid OFF vertex ${i}`);
+        }
+        vertices.push([x, y, z]);
+        if (hasVertexColors) {
+            const color = parseColor(line, 3, line.length - 3);
+            if (!color) {
+                throw new Error(`Invalid OFF color for vertex ${i}`);
+            }
+            vertexColors.push(color);
+        }
+    }
+
+    const positions = [];
+    const colors = [];
+    let hasColors = false;
+
+    for (let i = 0; i < faceCount; i++) {
+        const line = lines.shift();
+        if (!line) {
+            throw new Error(`Missing OFF face ${i}`);
+        }
+        let cursor = 0;
+        const points = Number(line[cursor++]);
+        if (!Number.isInteger(points) || points < 3) {
+            throw new Error(`Invalid OFF face ${i}`);
+        }
+        const indices = [];
+        for (let j = 0; j < points; j++) {
+            const index = Number(line[cursor++]);
+            if (!Number.isInteger(index) || index < 0 || index >= vertexCount) {
+                throw new Error(`Invalid OFF vertex index ${index} in face ${i}`);
+            }
+            indices.push(index);
+        }
+
+        const remainingFaceTokens = line.length - cursor;
+        const faceColor = parseColor(line, cursor, remainingFaceTokens);
+        if (faceColor) {
+            hasColors = true;
+        } else if (hasVertexColors) {
+            hasColors = true;
+        }
+
+        for (let j = 1; j < points - 1; j++) {
+            for (const index of [indices[0], indices[j], indices[j + 1]]) {
+                positions.push(...vertices[index]);
+                const color = faceColor || vertexColors[index] || [1, 1, 1];
+                colors.push(...color);
+            }
+        }
+    }
+
+    return {
+        positions: new Float32Array(positions),
+        colors: hasColors ? new Float32Array(colors) : null,
+    };
+}
+
+function triangleNormal(positions, offset) {
+    const ax = positions[offset];
+    const ay = positions[offset + 1];
+    const az = positions[offset + 2];
+    const bx = positions[offset + 3];
+    const by = positions[offset + 4];
+    const bz = positions[offset + 5];
+    const cx = positions[offset + 6];
+    const cy = positions[offset + 7];
+    const cz = positions[offset + 8];
+
+    const ux = bx - ax;
+    const uy = by - ay;
+    const uz = bz - az;
+    const vx = cx - ax;
+    const vy = cy - ay;
+    const vz = cz - az;
+
+    let nx = uy * vz - uz * vy;
+    let ny = uz * vx - ux * vz;
+    let nz = ux * vy - uy * vx;
+    const length = Math.hypot(nx, ny, nz);
+    if (length > 0) {
+        nx /= length;
+        ny /= length;
+        nz /= length;
+    }
+    return [nx, ny, nz];
+}
+
+export function offMeshToBinaryStl(mesh) {
+    const positions = mesh.positions;
+    if (positions.length % 9 !== 0) {
+        throw new Error("OFF mesh positions are not triangulated");
+    }
+    const triangleCount = positions.length / 9;
+    const bytes = new ArrayBuffer(84 + triangleCount * 50);
+    const view = new DataView(bytes);
+    const header = new TextEncoder().encode("Generated from OFF by web-openscad-editor");
+    new Uint8Array(bytes, 0, Math.min(header.length, 80)).set(header.slice(0, 80));
+    view.setUint32(80, triangleCount, true);
+
+    let cursor = 84;
+    for (let i = 0; i < positions.length; i += 9) {
+        const normal = triangleNormal(positions, i);
+        for (const value of normal) {
+            view.setFloat32(cursor, value, true);
+            cursor += 4;
+        }
+        for (let j = 0; j < 9; j++) {
+            view.setFloat32(cursor, positions[i + j], true);
+            cursor += 4;
+        }
+        view.setUint16(cursor, 0, true);
+        cursor += 2;
+    }
+
+    return new Uint8Array(bytes);
+}

--- a/src/static/editor/rendering.js
+++ b/src/static/editor/rendering.js
@@ -64,6 +64,7 @@ function showRenderError(dom, { summary, log }) {
  * @param {object} opts
  * @param {string}   opts.workerUrl
  * @param {string}   opts.scadInputPath
+ * @param {string}   opts.previewStyle
  * @param {*}        opts.exportFileStem     - null or {fixed?: string, js?: string}
  * @param {*}        opts.umamiTrackRender   - null or string[]
  * @param {*}        opts.umamiTrackExport   - null or string[]
@@ -74,6 +75,7 @@ function showRenderError(dom, { summary, log }) {
 export function createRenderer({
     workerUrl,
     scadInputPath,
+    previewStyle,
     exportFileStem,
     umamiTrackRender,
     umamiTrackExport,
@@ -186,6 +188,7 @@ export function createRenderer({
         worker.postMessage({
             type: "render",
             input: scadInputPath,
+            previewStyle: previewStyle || "shaded",
             normalParams: normalParams,
             additionalParams: additionalParams,
         });

--- a/src/worker.js.jinja2
+++ b/src/worker.js.jinja2
@@ -1,9 +1,12 @@
 import OpenSCAD from "./openscad-wasm/openscad.js"
 import * as THREE from "https://esm.sh/three@0.160.0"
-import {STLLoader} from "https://esm.sh/three@0.160.0/examples/jsm/loaders/STLLoader.js"
 import {GLTFExporter} from "https://esm.sh/three@0.160.0/examples/jsm/exporters/GLTFExporter.js"
+import {offMeshToBinaryStl, parseOffMesh} from "./{{ static_dir }}/editor/off.js"
 
 console.log("Worker started")
+
+const DEFAULT_TOP_COLOR = new THREE.Color(0x63696f)
+const DEFAULT_BOTTOM_COLOR = new THREE.Color(0xc4d0dd)
 
 const MAX_LOG_CHARS = 1024 * 1024
 let currentLog = ""
@@ -93,10 +96,6 @@ let runQueue = Promise.resolve()
 // OpenSCAD's WASM build aborts its runtime after a render.
 // Create a fresh instance for each render.
 
-function uint8ArrayToArrayBuffer(bytes) {
-    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
-}
-
 let cachedInputFiles = null
 let preloadAllInputsPromise = null
 
@@ -167,61 +166,68 @@ async function populateInstanceInputFiles(instance) {
     }
 }
 
-async function stlBytesToGlb(stlBytes) {
-    let geometry = new STLLoader().parse(uint8ArrayToArrayBuffer(stlBytes))
+function applyDepthCueing(geometry, previewStyle) {
+    const pos = geometry.getAttribute("position")
+    if (!pos || pos.count < 3) {
+        return
+    }
+    const baseColors = geometry.getAttribute("color")
+    const useFaceColors = previewStyle === "colors"
+
+    let minZ = Infinity
+    let maxZ = -Infinity
+    for (let i = 0; i < pos.count; i++) {
+        const z = pos.getZ(i)
+        if (z < minZ) minZ = z
+        if (z > maxZ) maxZ = z
+    }
+
+    const range = maxZ - minZ
+    if (!isFinite(range) || range <= 0) {
+        return
+    }
+
+    const colors = new Float32Array(pos.count * 3)
+    for (let i = 0; i < pos.count; i++) {
+        const z = pos.getZ(i)
+        const t = (z - minZ) / range
+        const k = i * 3
+
+        if (useFaceColors && baseColors) {
+            const r = baseColors.getX(i)
+            const g = baseColors.getY(i)
+            const b = baseColors.getZ(i)
+            // Keep the OpenSCAD color hue, but vary luminance with Z so
+            // pockets and vertical surfaces remain readable. Colored
+            // models need a narrower luminance range than the default
+            // gray preview or saturated colors wash out.
+            colors[k] = (r + (1 - r) * 0.08) * (1 - t) + (r * 0.78) * t
+            colors[k + 1] = (g + (1 - g) * 0.08) * (1 - t) + (g * 0.78) * t
+            colors[k + 2] = (b + (1 - b) * 0.08) * (1 - t) + (b * 0.78) * t
+        } else {
+            const c = DEFAULT_BOTTOM_COLOR.clone().lerp(DEFAULT_TOP_COLOR, t)
+            colors[k] = c.r
+            colors[k + 1] = c.g
+            colors[k + 2] = c.b
+        }
+    }
+    geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3))
+}
+
+async function geometryToGlb(geometry, previewStyle) {
     if (geometry.index) {
-        // STL is typically non-indexed, but if we ever get indexed geometry,
-        // convert to non-indexed so per-triangle vertex colors are stable.
+        // Keep vertex colors stable for per-face colored geometry.
         geometry = geometry.toNonIndexed()
     }
     if (!geometry.getAttribute("normal")) {
         geometry.computeVertexNormals()
     }
 
-    // Add simple depth cueing: tint triangles based on their Z position.
-    // This makes pockets easier to read without AO.
-    {
-        const pos = geometry.getAttribute("position")
-        if (pos && pos.count >= 3) {
-            let minZ = Infinity
-            let maxZ = -Infinity
-            for (let i = 0; i < pos.count; i++) {
-                const z = pos.getZ(i)
-                if (z < minZ) minZ = z
-                if (z > maxZ) maxZ = z
-            }
-
-            const range = maxZ - minZ
-            if (isFinite(range) && range > 0) {
-                // this logic shades faces based on Z position to make pockets easier to distinguish
-
-                // Base material color is 0x9aa3ad; these are subtle tints around it.
-                const topColor = new THREE.Color(0x63696f)
-                const bottomColor = new THREE.Color(0xc4d0dd)
-
-                 const colors = new Float32Array(pos.count * 3)
-                 // geometry is non-indexed, so each triangle is 3 consecutive vertices.
-                 // Compute the tint per-vertex based on its Z position to keep the gradient
-                 // continuous across faces (important for large vertical walls).
-                 for (let i = 0; i < pos.count; i++) {
-                     const z = pos.getZ(i)
-                     const t = (z - minZ) / range
-                     const c = bottomColor.clone().lerp(topColor, t)
-
-                     const k = i * 3
-                     colors[k] = c.r
-                     colors[k + 1] = c.g
-                     colors[k + 2] = c.b
-                 }
-                 geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3))
-             }
-         }
-     }
-
+    const neutralLighting = previewStyle === "colors"
     const material = new THREE.MeshStandardMaterial({
         color: 0xc4d0dd,
-        metalness: 0.8,
-        roughness: 0.4,
+        metalness: neutralLighting ? 0.0 : 0.8,
+        roughness: neutralLighting ? 0.55 : 0.4,
         flatShading: true,
         vertexColors: true,
     })
@@ -233,22 +239,22 @@ async function stlBytesToGlb(stlBytes) {
     scene.add(mesh)
 
     // Add a few basic lights so the exported GLB shades nicely even without an HDR environment.
-    const lightA = new THREE.DirectionalLight(0xd6629e, 20) // pink
+    const lightA = new THREE.DirectionalLight(neutralLighting ? 0xffffff : 0xd6629e, neutralLighting ? 4 : 20) // top right
     lightA.position.set(1000, 1000, 1000) // north east, top
     lightA.lookAt(0, 0, 0)
     scene.add(lightA)
 
-    const lightB = new THREE.DirectionalLight(0x5571a8, 20) // blue
+    const lightB = new THREE.DirectionalLight(neutralLighting ? 0xffffff : 0x5571a8, neutralLighting ? 2.5 : 20) // top left
     lightB.position.set(-1000, 1000, 1000) // north west, top
     lightB.lookAt(0, 0, 0)
     scene.add(lightB)
 
-    const lightC = new THREE.DirectionalLight(0xbf86bb, 15) // purple
+    const lightC = new THREE.DirectionalLight(neutralLighting ? 0xffffff : 0xbf86bb, neutralLighting ? 1 : 15) // bottom
     lightC.position.set(0, -1000, -1000) // south, bottom
     lightC.lookAt(0, 0, 0)
     scene.add(lightC)
 
-    const lightD = new THREE.DirectionalLight(0xbf86bb, 15) // purple
+    const lightD = new THREE.DirectionalLight(neutralLighting ? 0xffffff : 0xbf86bb, neutralLighting ? 1.5 : 15) // front
     lightD.position.set(0, -1000, 1000) // south, top
     lightD.lookAt(0, 0, 0)
     scene.add(lightD)
@@ -268,6 +274,21 @@ async function stlBytesToGlb(stlBytes) {
             { binary: true },
         )
     })
+}
+
+function offBytesToMesh(offBytes) {
+    const text = new TextDecoder().decode(offBytes)
+    return parseOffMesh(text)
+}
+
+async function offMeshToGlb(mesh, previewStyle) {
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute("position", new THREE.BufferAttribute(mesh.positions, 3))
+    if (mesh.colors) {
+        geometry.setAttribute("color", new THREE.BufferAttribute(mesh.colors, 3))
+    }
+    applyDepthCueing(geometry, previewStyle)
+    return geometryToGlb(geometry, previewStyle)
 }
 
 async function createInstance() {
@@ -290,7 +311,7 @@ async function createInstance() {
     return instance
 }
 
-async function renderOnce({ input, normalParams, additionalParams }) {
+async function renderOnce({ input, normalParams, additionalParams, previewStyle }) {
     const instance = await createInstance()
 
     // Eagerly fetch all inputs once (parallel), then materialize them in each
@@ -316,9 +337,14 @@ async function renderOnce({ input, normalParams, additionalParams }) {
         }),
     )
 
-    const output = "/output.stl"
+    const output = "/output.off"
     try {
         instance.FS.unlink(output)
+    } catch (e) {
+        // ignore
+    }
+    try {
+        instance.FS.unlink("/camera-summary.json")
     } catch (e) {
         // ignore
     }
@@ -328,7 +354,7 @@ async function renderOnce({ input, normalParams, additionalParams }) {
         output,
         {% for feat in config.openscad.enable_features %}"--enable={{ feat }}",
         {% endfor %}
-        "--export-format=binstl",
+        "--export-format=off",
         "-p",
         "/parameters.json",
         "-P",
@@ -345,8 +371,10 @@ async function renderOnce({ input, normalParams, additionalParams }) {
     logInfo("Line:", args)
     try {
         instance.callMain(args)
-        const stlBytes = instance.FS.readFile(output)
-        const glb = await stlBytesToGlb(stlBytes)
+        const offBytes = instance.FS.readFile(output)
+        const mesh = offBytesToMesh(offBytes)
+        const glb = await offMeshToGlb(mesh, previewStyle || "shaded")
+        const stl = offMeshToBinaryStl(mesh)
         let camera = null
         try {
             const summaryBytes = instance.FS.readFile("/camera-summary.json", { encoding: "utf8" })
@@ -360,7 +388,7 @@ async function renderOnce({ input, normalParams, additionalParams }) {
         self.postMessage({
             type: "ok",
             glb: glb,
-            stl: stlBytes,
+            stl: stl,
             camera: camera,
         })
     } catch (e) {
@@ -391,6 +419,7 @@ self.addEventListener("message", (event) => {
             input: msg.input,
             normalParams: msg.normalParams,
             additionalParams: msg.additionalParams,
+            previewStyle: msg.previewStyle,
         })
     })
     runQueue.catch((e) => {

--- a/test.scad
+++ b/test.scad
@@ -97,6 +97,7 @@ module label_3d(str, font, size, depth, anchor) {
 
 module bosl2_sample(size) {
   translate([0, -depth / 2 - size * 0.8, size / 4])
+    color("#6fbf73")
     cuboid(
       [size, size, size / 2],
       rounding = size / 8,
@@ -117,6 +118,7 @@ module shading_demo_structures(model_w, model_d, h, wall_w, wall_d, pocket_d) {
     cube([wall_w, wall_d, h], center = true);
 
   // pocketed wall
+  color("#d95f5f")
   difference() {
     translate([spacing_x, spacing_y, h / 2])
       cube([wall_w, wall_d, h], center = true);
@@ -138,11 +140,14 @@ model_h = height;
 difference() {
   union() {
     if (shape == "rounded box")
-      rounded_box(width, depth, model_h, rounding);
+      color("#4c78a8")
+        rounded_box(width, depth, model_h, rounding);
     else if (shape == "capsule")
-      capsule(width, depth, model_h);
+      color("#f2a541")
+        capsule(width, depth, model_h);
     else
-      ring(min(width, depth), min(width, depth) * 0.6, model_h);
+      color("#8e6bbf")
+        ring(min(width, depth), min(width, depth) * 0.6, model_h);
 
     if (show_baseplate && baseplate_thickness > 0)
       translate([0, 0, -baseplate_thickness])
@@ -151,7 +156,8 @@ difference() {
     if (show_text) {
       // Put text on the top face.
       translate([0, 0, model_h + text_z_offset])
-        label_3d(text_string, text_font, text_size, text_depth, text_anchor);
+        color("#f0e442")
+          label_3d(text_string, text_font, text_size, text_depth, text_anchor);
     }
 
     if (show_bosl2_sample)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -153,3 +153,24 @@ def test_template_multi():
     assert len(models) == 1
     assert models[0].description_extra_html == "foo"
     assert models[0].additional_params == [ "fizz.json", "buzz.json"]
+
+def test_preview_style_config():
+    def style_value(model_config):
+        value = model_config.preview_style
+        return value.value if isinstance(value, config_generated.PreviewStyle) else value
+
+    default_config = config_generated.WebOpenscadEditorConfiguration.model_validate({
+        "model": [ { "file": "model.scad" } ]
+    })
+    assert style_value(default_config.model[0]) is None
+
+    colors_config = config_generated.WebOpenscadEditorConfiguration.model_validate({
+        "model": [ { "file": "model.scad", "preview-style": "colors" } ]
+    })
+    assert style_value(colors_config.model[0]) == "colors"
+
+    models = model.flatten_model_configs(config_generated.WebOpenscadEditorConfiguration.model_validate({
+        "model-template": { "default": { "preview-style": "colors" } },
+        "model": [ { "file": "model.scad" } ]
+    }))
+    assert style_value(models[0]) == "colors"

--- a/tests/test_off_parser.py
+++ b/tests/test_off_parser.py
@@ -1,0 +1,112 @@
+import subprocess
+import textwrap
+
+
+def run_node(script: str):
+    subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        check=True,
+        text=True,
+    )
+
+
+def test_off_parser_triangulates_colored_faces():
+    run_node(
+        textwrap.dedent(
+            """
+            import assert from "node:assert/strict";
+            import { parseOffMesh } from "./src/static/editor/off.js";
+
+            const mesh = parseOffMesh(`
+            OFF
+            4 1 0
+            0 0 0
+            1 0 0
+            1 1 0
+            0 1 0
+            4 0 1 2 3 255 128 0 1
+            `);
+
+            assert.equal(mesh.positions.length, 18);
+            assert.equal(mesh.colors.length, 18);
+            const firstColor = Array.from(mesh.colors.slice(0, 3));
+            assert.equal(firstColor[0], 1);
+            assert.ok(Math.abs(firstColor[1] - 128 / 255) < 1e-6);
+            assert.equal(firstColor[2], 0);
+            assert.deepEqual(Array.from(mesh.positions.slice(0, 9)), [
+                0, 0, 0,
+                1, 0, 0,
+                1, 1, 0,
+            ]);
+            assert.deepEqual(Array.from(mesh.positions.slice(9, 18)), [
+                0, 0, 0,
+                1, 1, 0,
+                0, 1, 0,
+            ]);
+            """
+        )
+    )
+
+
+def test_off_parser_keeps_adjacent_uncolored_faces_uncolored():
+    run_node(
+        textwrap.dedent(
+            """
+            import assert from "node:assert/strict";
+            import { parseOffMesh } from "./src/static/editor/off.js";
+
+            const mesh = parseOffMesh(`
+            OFF
+            5 2 0
+            0 0 0
+            1 0 0
+            0 1 0
+            0 0 1
+            1 1 1
+            3 0 1 2
+            3 2 3 4
+            `);
+
+            assert.equal(mesh.positions.length, 18);
+            assert.equal(mesh.colors, null);
+            """
+        )
+    )
+
+
+def test_off_mesh_to_binary_stl():
+    run_node(
+        textwrap.dedent(
+            """
+            import assert from "node:assert/strict";
+            import { offMeshToBinaryStl, parseOffMesh } from "./src/static/editor/off.js";
+
+            const mesh = parseOffMesh(`
+            OFF
+            3 1 0
+            0 0 0
+            1 0 0
+            0 1 0
+            3 0 1 2 1 0 0
+            `);
+            const stl = offMeshToBinaryStl(mesh);
+            const view = new DataView(stl.buffer, stl.byteOffset, stl.byteLength);
+
+            assert.equal(stl.byteLength, 134);
+            assert.equal(view.getUint32(80, true), 1);
+            assert.equal(view.getFloat32(84, true), 0);
+            assert.equal(view.getFloat32(88, true), 0);
+            assert.equal(view.getFloat32(92, true), 1);
+            assert.equal(view.getFloat32(96, true), 0);
+            assert.equal(view.getFloat32(100, true), 0);
+            assert.equal(view.getFloat32(104, true), 0);
+            assert.equal(view.getFloat32(108, true), 1);
+            assert.equal(view.getFloat32(112, true), 0);
+            assert.equal(view.getFloat32(116, true), 0);
+            assert.equal(view.getFloat32(120, true), 0);
+            assert.equal(view.getFloat32(124, true), 1);
+            assert.equal(view.getFloat32(128, true), 0);
+            assert.equal(view.getUint16(132, true), 0);
+            """
+        )
+    )


### PR DESCRIPTION
## Summary
- Render previews from OpenSCAD OFF output so face colors can be shown
- Convert the same OFF mesh to binary STL in JavaScript for downloads, keeping a single OpenSCAD render per update
- Add per-model `preview-style` with `shaded` default and `colors` mode for colored previews
- Add OFF parser/STL serializer tests and update the sample model/config

Closes #31

## Tests
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest`